### PR TITLE
Migrate to uv package manager with pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ filterpy/kalman/i.py
 filterpy/inprogress.py
 .pytest_cache
 
+# uv
+.venv/
+uv.lock
+.python-version
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "filterpy"
+version = "1.4.5"
+description = "Kalman filtering and optimal estimation library"
+readme = "README.rst"
+authors = [
+    { name = "Roger Labbe", email = "rlabbejr@gmail.com" }
+]
+requires-python = ">=3.6"
+dependencies = [
+    "numpy",
+    "scipy",
+    "matplotlib",
+]
+keywords = ["Kalman", "filters", "filtering", "optimal", "estimation", "tracking"]
+license = { text = "MIT" }
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Utilities",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+
+[project.urls]
+Homepage = "https://github.com/rlabbe/filterpy"
+Repository = "https://github.com/rlabbe/filterpy"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["filterpy"]


### PR DESCRIPTION
## Summary
- Adds modern `pyproject.toml` with all metadata from `setup.py`
- Configures hatchling as the build backend for compatibility with uv
- Updates `.gitignore` to exclude uv-specific artifacts (.venv/, uv.lock, .python-version)
- Maintains backward compatibility with Python 3.6+
- Preserves all package metadata, classifiers, and dependencies

## Benefits
- Enables modern Python packaging workflows using uv
- Follows PEP 517/518 standards with declarative configuration
- Simplifies dependency management with `uv sync`
- Retains `setup.py` for backward compatibility

## Test plan
- [x] Successfully built the package with uv
- [x] Verified package installation with `uv sync`
- [x] Tested imports: `import filterpy` and submodules (KalmanFilter, Q_discrete_white_noise)
- [x] Confirmed version and module availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)