### PR TITLE
feat: add markdown link checker to pre-commit hooks

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,24 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    },
+    {
+      "pattern": "^mailto:"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 301, 302, 307, 308, 403, 429]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,11 @@ repos:
     rev: v1.1.405
     hooks:
       - id: pyright
+
+  # Documentation link checker
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ['--config', '.markdown-link-check.json']
+        files: ^docs/.*\.md$

--- a/docs/filters/extended-kalman-filter.md
+++ b/docs/filters/extended-kalman-filter.md
@@ -33,9 +33,6 @@ github repo:
 read online:
     http://nbviewer.ipython.org/github/rlabbe/Kalman-and-Bayesian-Filters-in-Python/blob/master/table_of_contents.ipynb
 
-PDF version (often lags the two sources above)
-    https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python/blob/master/Kalman_and_Bayesian_Filters_in_Python.pdf
-
 -------
 
 ## API Reference

--- a/docs/filters/kalman-filter.md
+++ b/docs/filters/kalman-filter.md
@@ -204,9 +204,6 @@ github repo:
 read online:
     http://nbviewer.ipython.org/github/rlabbe/Kalman-and-Bayesian-Filters-in-Python/blob/master/table_of_contents.ipynb
 
-PDF version (often lags the two sources above)
-    https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python/blob/master/Kalman_and_Bayesian_Filters_in_Python.pdf
-
 -------
 
 ## API Reference


### PR DESCRIPTION
## Summary

Adds automated link checking to the pre-commit workflow to ensure all documentation links remain valid.

## Changes

### Pre-commit Configuration
- Added `markdown-link-check` hook to `.pre-commit-config.yaml`
- Hook only runs on files matching `^docs/.*\.md$`
- Integrated with existing pre-commit workflow

### Link Checker Configuration
- Created `.markdown-link-check.json` with sensible defaults:
  - Ignores anchor links (`#`) and mailto links
  - 10 second timeout per link
  - Retry on 429 (rate limit) with exponential backoff
  - Considers 403/429 as "alive" (common for GitHub)
  - 3 retry attempts with 30s fallback delay

### Documentation Fixes
- Removed broken PDF link from `docs/filters/kalman-filter.md`
- Removed broken PDF link from `docs/filters/extended-kalman-filter.md`
- All documentation links now pass validation

## Benefits

✅ **Prevents Broken Links** - Catches dead links before they're committed
✅ **Automated Validation** - Runs automatically on every commit
✅ **Fast Feedback** - Developers know immediately if links are broken
✅ **Documentation Quality** - Ensures better user experience

## Testing

```bash
# Test on all documentation files
pre-commit run markdown-link-check --all-files

# Result: All links passed validation
```

## Example Output

When a broken link is found:
```
FILE: docs/filters/kalman-filter.md
  [✓] https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
  [✖] https://github.com/rlabbe/.../broken-link.pdf

  ERROR: 1 dead links found!
  [✖] https://github.com/.../broken-link.pdf → Status: 404
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)