### PR TITLE
style: center README image and make it full width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bayesian Filters - Kalman filters and other optimal and non-optimal estimation filters in Python
 
-<img width="467" height="272" alt="image" src="https://github.com/user-attachments/assets/90b0b305-3128-4806-a72c-a061d01a854b" />
+<p align="center">
+  <img width="100%" alt="Kalman Filter Illustration" src="https://github.com/user-attachments/assets/90b0b305-3128-4806-a72c-a061d01a854b" />
+</p>
 
 For people new to Kalman filters, they're well explained here https://www.youtube.com/watch?v=IFeCIbljreY (credit for the above image)
 


### PR DESCRIPTION
## Changes

Updated the README image to be centered and responsive:

### Before
```markdown
<img width="467" height="272" alt="image" src="..." />
```
- Fixed width (467px)
- Left-aligned
- Basic alt text

### After
```markdown
<p align="center">
  <img width="100%" alt="Kalman Filter Illustration" src="..." />
</p>
```
- Full width (100%) - responsive to page width
- Centered
- Improved alt text for accessibility

## Result

The Kalman filter illustration now:
- ✅ Centers nicely on the page
- ✅ Scales to match page width
- ✅ Maintains aspect ratio
- ✅ Looks better on all screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)