### PR TITLE
refactor: replace all filterpy references with bayesian_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 For people new to Kalman filters, they're well explained here https://www.youtube.com/watch?v=IFeCIbljreY (credit for the above image)
 
-[![PyPI version](https://img.shields.io/pypi/v/filterpy.svg)](https://pypi.python.org/pypi/filterpy)
-[![Documentation Status](https://readthedocs.org/projects/pip/badge/?version=latest&style=flat)](https://filterpy.readthedocs.io/en/latest/)
+[![PyPI version](https://img.shields.io/pypi/v/bayesian-filters.svg)](https://pypi.org/project/bayesian-filters/)
+[![Documentation Status](https://img.shields.io/badge/docs-online-brightgreen)](https://georgepearse.github.io/bayesian_filters)
 
-> **Note**: This is a personal fork of the original FilterPy library. The original project can be found at https://github.com/rlabbe/filterpy
+> **Note**: This is a personal fork of the original FilterPy library (now renamed to Bayesian Filters). The original project can be found at https://github.com/rlabbe/filterpy
 
 This library provides Kalman filtering and various related optimal and non-optimal filtering software written in Python. It contains Kalman filters, Extended Kalman filters, Unscented Kalman filters, Kalman smoothers, Least Squares filters, fading memory filters, g-h filters, discrete Bayes, and more.
 
@@ -23,25 +23,28 @@ All computations use NumPy and SciPy.
 
 ## Documentation
 
-Sphinx generated documentation lives at http://filterpy.readthedocs.org/.
+Documentation is available at https://georgepearse.github.io/bayesian_filters
 
 ## Installation
 
 ```bash
-uv pip install filterpy
+uv pip install bayesian-filters
 ```
 
 
 ## Basic Usage
 
-Full documentation is at https://filterpy.readthedocs.io/en/latest/
+Full documentation is at https://georgepearse.github.io/bayesian_filters
 
 ### Import the filters
 
 ```python
 import numpy as np
-from filterpy.kalman import KalmanFilter
-from filterpy.common import Q_discrete_white_noise
+import bayesian_filters as bf
+
+# Or import specific modules
+from bayesian_filters.kalman import KalmanFilter
+from bayesian_filters.common import Q_discrete_white_noise
 ```
 
 ### Create the filter
@@ -112,6 +115,8 @@ The tests include both unit tests and visual verification. Visual plots are ofte
 
 ## References
 
+### Books
+
 The original author uses three main reference texts:
 
 1. **Paul Zarchan's 'Fundamentals of Kalman Filtering: A Practical Approach'** - Excellent for practical applications rather than theoretical thesis work.
@@ -120,9 +125,13 @@ The original author uses three main reference texts:
 
 3. **Bar-Shalom's 'Estimation with Applications to Tracking and Navigation'** - More mathematical than the previous two. Recommended after gaining some background in control theory or optimal estimation. Every sentence is crystal clear with precise language, and abstract mathematical statements are followed with practical explanations.
 
+### Online Resources
+
+- **[Kalman Filter Background](https://kalmanfilter.net/background.html)** - Comprehensive background and theory on Kalman filtering
+
 ## License
 
-[![License](https://anaconda.org/rlabbe/filterpy/badges/license.svg)](https://anaconda.org/rlabbe/filterpy)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/GeorgePearse/bayesian_filters/blob/master/LICENSE)
 
 The MIT License (MIT)
 

--- a/bayesian_filters/__init__.py
+++ b/bayesian_filters/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Copyright 2015 Roger R Labbe Jr.
 
-filterpy library.
-http://github.com/rlabbe/filterpy
+bayesian_filters library.
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/__init__.py
+++ b/bayesian_filters/common/__init__.py
@@ -1,10 +1,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/discretization.py
+++ b/bayesian_filters/common/discretization.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/helpers.py
+++ b/bayesian_filters/common/helpers.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/kinematic.py
+++ b/bayesian_filters/common/kinematic.py
@@ -4,10 +4,10 @@
 """Copyright 2018 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/tests/test_discretization.py
+++ b/bayesian_filters/common/tests/test_discretization.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/common/tests/test_helpers.py
+++ b/bayesian_filters/common/tests/test_helpers.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/discrete_bayes/__init__.py
+++ b/bayesian_filters/discrete_bayes/__init__.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/discrete_bayes/discrete_bayes.py
+++ b/bayesian_filters/discrete_bayes/discrete_bayes.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/discrete_bayes/tests/test_discrete_bayes.py
+++ b/bayesian_filters/discrete_bayes/tests/test_discrete_bayes.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/examples/GetRadar.py
+++ b/bayesian_filters/examples/GetRadar.py
@@ -1,10 +1,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/examples/RadarUKF.py
+++ b/bayesian_filters/examples/RadarUKF.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/examples/bearing_only.py
+++ b/bayesian_filters/examples/bearing_only.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/examples/radar_sim.py
+++ b/bayesian_filters/examples/radar_sim.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/gh/__init__.py
+++ b/bayesian_filters/gh/__init__.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/gh/gh_filter.py
+++ b/bayesian_filters/gh/gh_filter.py
@@ -7,10 +7,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -391,8 +391,8 @@ class GHFilter(object):
         save_predictions : boolean
             the predictions will be saved and returned if this is true
 
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
+        saver : bayesian_filters.common.Saver, optional
+            bayesian_filters.common.Saver object. If provided, saver.save() will be
             called after every epoch
 
 

--- a/bayesian_filters/gh/tests/test_gh.py
+++ b/bayesian_filters/gh/tests/test_gh.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/hinfinity/__init__.py
+++ b/bayesian_filters/hinfinity/__init__.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/hinfinity/hinfinity_filter.py
+++ b/bayesian_filters/hinfinity/hinfinity_filter.py
@@ -6,10 +6,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -167,8 +167,8 @@ class HInfinityFilter(object):
             controls whether the order of operations is update followed by
             predict, or predict followed by update.
 
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
+        saver : bayesian_filters.common.Saver, optional
+            bayesian_filters.common.Saver object. If provided, saver.save() will be
             called after every epoch
 
         Returns

--- a/bayesian_filters/hinfinity/tests/test_hinfinity.py
+++ b/bayesian_filters/hinfinity/tests/test_hinfinity.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Copyright 2014 Roger R Labbe Jr.
 
-filterpy library.
-http://github.com/rlabbe/filterpy
+bayesian_filters library.
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/CubatureKalmanFilter.py
+++ b/bayesian_filters/kalman/CubatureKalmanFilter.py
@@ -5,10 +5,10 @@
 """Copyright 2016 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/EKF.py
+++ b/bayesian_filters/kalman/EKF.py
@@ -5,10 +5,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/UKF.py
+++ b/bayesian_filters/kalman/UKF.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -242,7 +242,7 @@ class UnscentedKalmanFilter(object):
     For in depth explanations see my book Kalman and Bayesian Filters in Python
     https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
 
-    Also see the filterpy/kalman/tests subdirectory for test code that
+    Also see the bayesian_filters/kalman/tests subdirectory for test code that
     may be illuminating.
 
     References
@@ -563,8 +563,8 @@ class UnscentedKalmanFilter(object):
             work - you can use x_mean_fn and z_mean_fn to alter the behavior
             of the unscented transform.
 
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
+        saver : bayesian_filters.common.Saver, optional
+            bayesian_filters.common.Saver object. If provided, saver.save() will be
             called after every epoch
 
         Returns

--- a/bayesian_filters/kalman/__init__.py
+++ b/bayesian_filters/kalman/__init__.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/ensemble_kalman_filter.py
+++ b/bayesian_filters/kalman/ensemble_kalman_filter.py
@@ -5,10 +5,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/fading_memory.py
+++ b/bayesian_filters/kalman/fading_memory.py
@@ -5,10 +5,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/fixed_lag_smoother.py
+++ b/bayesian_filters/kalman/fixed_lag_smoother.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/information_filter.py
+++ b/bayesian_filters/kalman/information_filter.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -303,8 +303,8 @@ class InformationFilter(object):
             controls whether the order of operations is update followed by
             predict, or predict followed by update. Default is predict->update.
 
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
+        saver : bayesian_filters.common.Saver, optional
+            bayesian_filters.common.Saver object. If provided, saver.save() will be
             called after every epoch
 
         Returns

--- a/bayesian_filters/kalman/kalman_filter.py
+++ b/bayesian_filters/kalman/kalman_filter.py
@@ -104,10 +104,10 @@ book cited below. In it I both teach Kalman filtering from basic
 principles, and teach the use of this library in great detail.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -359,7 +359,7 @@ class KalmanFilter(object):
         pseudo inverse, set it to that instead: kf.inv = np.linalg.pinv
 
         This is only used to invert self.S. If you know it is diagonal, you
-        might choose to set it to filterpy.common.inv_diagonal, which is
+        might choose to set it to bayesian_filters.common.inv_diagonal, which is
         several times faster than numpy.linalg.inv for diagonal matrices.
 
     alpha : float
@@ -896,8 +896,8 @@ class KalmanFilter(object):
              controls whether the order of operations is update followed by
              predict, or predict followed by update. Default is predict->update.
 
-         saver : filterpy.common.Saver, optional
-             filterpy.common.Saver object. If provided, saver.save() will be
+         saver : bayesian_filters.common.Saver, optional
+             bayesian_filters.common.Saver object. If provided, saver.save() will be
              called after every epoch
 
          Returns
@@ -1685,8 +1685,8 @@ def batch_filter(x, P, zs, Fs, Qs, Hs, Rs, Bs=None, us=None, update_first=False,
         controls whether the order of operations is update followed by
         predict, or predict followed by update. Default is predict->update.
 
-        saver : filterpy.common.Saver, optional
-            filterpy.common.Saver object. If provided, saver.save() will be
+        saver : bayesian_filters.common.Saver, optional
+            bayesian_filters.common.Saver object. If provided, saver.save() will be
             called after every epoch
 
     Returns

--- a/bayesian_filters/kalman/mmae.py
+++ b/bayesian_filters/kalman/mmae.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/sigma_points.py
+++ b/bayesian_filters/kalman/sigma_points.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/square_root.py
+++ b/bayesian_filters/kalman/square_root.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_ekf.py
+++ b/bayesian_filters/kalman/tests/test_ekf.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_enkf.py
+++ b/bayesian_filters/kalman/tests/test_enkf.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_fls.py
+++ b/bayesian_filters/kalman/tests/test_fls.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_fm.py
+++ b/bayesian_filters/kalman/tests/test_fm.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_imm.py
+++ b/bayesian_filters/kalman/tests/test_imm.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_information.py
+++ b/bayesian_filters/kalman/tests/test_information.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_kf.py
+++ b/bayesian_filters/kalman/tests/test_kf.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_mmae.py
+++ b/bayesian_filters/kalman/tests/test_mmae.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_rts.py
+++ b/bayesian_filters/kalman/tests/test_rts.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_sensor_fusion.py
+++ b/bayesian_filters/kalman/tests/test_sensor_fusion.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_sqrtkf.py
+++ b/bayesian_filters/kalman/tests/test_sqrtkf.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/tests/test_ukf.py
+++ b/bayesian_filters/kalman/tests/test_ukf.py
@@ -7,10 +7,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
@@ -1007,7 +1007,7 @@ def test_vhartman():
     """
     Code provided by vhartman on github #172
 
-    https://github.com/rlabbe/filterpy/issues/172
+    https://github.com/GeorgePearse/bayesian_filters/issues/172
     """
 
     def fx(x, dt):

--- a/bayesian_filters/kalman/tests/ukf2.py
+++ b/bayesian_filters/kalman/tests/ukf2.py
@@ -3,10 +3,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/kalman/unscented_transform.py
+++ b/bayesian_filters/kalman/unscented_transform.py
@@ -4,10 +4,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/leastsq/__init__.py
+++ b/bayesian_filters/leastsq/__init__.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/leastsq/least_squares.py
+++ b/bayesian_filters/leastsq/least_squares.py
@@ -6,10 +6,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/leastsq/tests/test_lsq.py
+++ b/bayesian_filters/leastsq/tests/test_lsq.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/memory/__init__.py
+++ b/bayesian_filters/memory/__init__.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/memory/fading_memory.py
+++ b/bayesian_filters/memory/fading_memory.py
@@ -7,10 +7,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/memory/tests/test_fading_memory.py
+++ b/bayesian_filters/memory/tests/test_fading_memory.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/monte_carlo/__init__.py
+++ b/bayesian_filters/monte_carlo/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Copyright 2015 Roger R Labbe Jr.
 
-filterpy library.
-http://github.com/rlabbe/filterpy
+bayesian_filters library.
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/monte_carlo/resampling.py
+++ b/bayesian_filters/monte_carlo/resampling.py
@@ -7,10 +7,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/stats/__init__.py
+++ b/bayesian_filters/stats/__init__.py
@@ -1,10 +1,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/stats/stats.py
+++ b/bayesian_filters/stats/stats.py
@@ -6,10 +6,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python

--- a/bayesian_filters/stats/tests/test_stats.py
+++ b/bayesian_filters/stats/tests/test_stats.py
@@ -2,10 +2,10 @@
 """Copyright 2015 Roger R Labbe Jr.
 
 FilterPy library.
-http://github.com/rlabbe/filterpy
+https://github.com/GeorgePearse/bayesian_filters
 
 Documentation at:
-https://filterpy.readthedocs.org
+https://georgepearse.github.io/bayesian_filters
 
 Supporting book at:
 https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python


### PR DESCRIPTION
## Summary

Comprehensively replaces all `filterpy` references with `bayesian_filters` across the entire codebase, reflecting the renamed package.

## Changes

### README.md Updates

**Import Examples:**
```python
import numpy as np
import bayesian_filters as bf

# Or import specific modules
from bayesian_filters.kalman import KalmanFilter
from bayesian_filters.common import Q_discrete_white_noise
```

**Installation:**
```bash
uv pip install bayesian-filters
```

**Documentation:**
- Updated all URLs to GitHub Pages: https://georgepearse.github.io/bayesian_filters
- Updated badges (PyPI, docs, license)
- Added References section with Kalman Filter Background resource

### Source Code Updates (57 files)

**Docstring References:**
- `filterpy.common.Saver` → `bayesian_filters.common.Saver`
- `filterpy.common.inv_diagonal` → `bayesian_filters.common.inv_diagonal`
- `filterpy library` → `bayesian_filters library`
- `filterpy/kalman/tests` → `bayesian_filters/kalman/tests`

**URLs:**
- `http://github.com/rlabbe/filterpy` → `https://github.com/GeorgePearse/bayesian_filters`
- `https://filterpy.readthedocs.org` → `https://georgepearse.github.io/bayesian_filters`

### Modules Updated

All modules across the codebase:
- `kalman/` - Kalman filter implementations
- `common/` - Common utilities
- `gh/` - g-h filters
- `stats/` - Statistical functions
- `discrete_bayes/` - Discrete Bayesian filters
- `monte_carlo/` - Monte Carlo methods
- `leastsq/` - Least squares
- `hinfinity/` - H-infinity filters
- `memory/` - Fading memory filters
- `examples/` - Example code
- All test files

## Impact

- ✅ All imports now use `bayesian_filters` namespace
- ✅ Documentation links point to new GitHub Pages site
- ✅ Installation instructions updated for new package name
- ✅ No breaking changes to actual code functionality
- ✅ All tests pass
- ✅ Pre-commit hooks pass

## Migration Guide

For users upgrading from filterpy:

```python
# Old
from filterpy.kalman import KalmanFilter
from filterpy.common import Q_discrete_white_noise

# New
from bayesian_filters.kalman import KalmanFilter
from bayesian_filters.common import Q_discrete_white_noise

# Or use alias
import bayesian_filters as bf
kf = bf.kalman.KalmanFilter(dim_x=2, dim_z=1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)