### PR TITLE
fix: use GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,10 +41,11 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build
 
-      - name: Configure git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
 
       - name: Deploy to GitHub Pages
-        run: uv run mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Fixes the 404 error on the deployed GitHub Pages site.

## Root Cause

GitHub Pages was configured to serve from the `master` branch, but `mkdocs gh-deploy` was pushing built documentation to the `gh-pages` branch. This mismatch caused the site to show a 404 error despite successful workflow runs.

## Solution

Updated the deployment workflow to use GitHub Actions native Pages deployment:
- Replaced `mkdocs gh-deploy` command with `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`
- The built documentation (in `site/` directory) is now uploaded as a GitHub Pages artifact
- GitHub Actions deploys the artifact to Pages, which is configured to use the workflow deployment method

This aligns with the workflow's existing `environment: github-pages` configuration and uses the modern, recommended approach for GitHub Pages deployment.

## Test Plan

- [x] Workflow will trigger on merge to master
- [ ] Verify the site loads correctly at https://georgepearse.github.io/bayesian_filters/
- [ ] Check that navigation and all pages work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)