### PR TITLE
docs: add Kalman and Bayesian Filters in Python book to references

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The original author uses three main reference texts:
 
 ### Online Resources
 
+- **[Kalman and Bayesian Filters in Python](https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python)** - Free online book with Jupyter notebooks teaching Kalman filtering and Bayesian statistics. Written by the original FilterPy author, this is the companion book to this library and provides excellent intuitive explanations with interactive examples.
 - **[Kalman Filter Background](https://kalmanfilter.net/background.html)** - Comprehensive background and theory on Kalman filtering
 
 ## License


### PR DESCRIPTION
## Summary

Adds Roger Labbe's excellent free online book "Kalman and Bayesian Filters in Python" to the Online Resources section.

## Why This Resource?

This book is:
- Written by the original FilterPy author
- The companion book to this library
- Free and open source
- Contains interactive Jupyter notebooks
- Provides intuitive explanations with hands-on examples
- The best resource for learning Kalman filtering with this library

## Changes

Added prominent entry in the Online Resources section with:
- Link to the GitHub repository: https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python
- Description highlighting that it's written by the original FilterPy author
- Emphasis on the interactive nature and excellent explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)