### PR TITLE
Avoid deprecation warning for string

### DIFF
--- a/bayesian_filters/common/helpers.py
+++ b/bayesian_filters/common/helpers.py
@@ -376,7 +376,7 @@ def outer_product_sum(A, B=None):
     r"""
     Computes the sum of the outer products of the rows in A and B
 
-        P = \Sum {A[i] B[i].T} for i in 0..N
+        P = \\Sum {A[i] B[i].T} for i in 0..N
 
         Notionally:
 


### PR DESCRIPTION
Hi,
just to get rid of a warning, I changed `\Sum` to `\\Sum`.

Best,
Florian